### PR TITLE
Add install targets for configuration files

### DIFF
--- a/darknet_ros/CMakeLists.txt
+++ b/darknet_ros/CMakeLists.txt
@@ -203,6 +203,10 @@ install(
   FILES_MATCHING PATTERN "*.h"
 )
 
+install(DIRECTORY config launch yolo_network_config
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
 # Download yolov2-tiny.weights
 set(PATH "${CMAKE_CURRENT_SOURCE_DIR}/yolo_network_config/weights")
 set(FILE "${PATH}/yolov2-tiny.weights")


### PR DESCRIPTION
Adds the `launch`, `config`, and `yolo_network_config` folders to the install target for `darknet_ros` so they are available in the catkin install directory.

This is important in our production environment for Docker images as we _install_ packages in the production stage rather than using the devel space.